### PR TITLE
refactor: Rename flow to traffic for consistency

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,13 +6,14 @@ import (
 	"China_Telecom_Monitor/tools"
 	"flag"
 	"fmt"
+	"strings"
+
 	"github.com/golang-module/carbon/v2"
 	"github.com/kataras/iris/v12"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
-	"strings"
 )
 
 var Version = "v2.0.2"
@@ -44,15 +45,15 @@ func main() {
 
 // 初始化配置
 func initFlag() {
-	flag.StringVar(&configs.Prot, "prot", "8080", "--prot 8080")
+	flag.StringVar(&configs.Port, "port", "8080", "--port 8080")
 	flag.StringVar(&configs.Username, "username", "", "--username 1xxxxxxxxxx #电信账号用户名, 必填")
 	flag.StringVar(&configs.Password, "password", "", "--password xxxxx #电信账号密码, 必填")
-	flag.IntVar(&configs.LoginIntervalTime, "loginIntervalTime", 43200, "--loginIntervalTime 43200 #电信登录间隔时间（防止被封号），秒")
-	flag.Int64Var(&configs.TimeOut, "timeOut", 30, "--timeOut 30 #访问电信接口请求超时时间，秒")
-	flag.IntVar(&configs.IntervalsTime, "intervalsTime", 180, "--intervalsTime 180 #接口防止重刷时间")
+	flag.IntVar(&configs.LoginInterval, "loginInterval", 43200, "--loginInterval 43200 #电信登录间隔时间（防止被封号），秒")
+	flag.Int64Var(&configs.Timeout, "timeout", 30, "--timeout 30 #访问电信接口请求超时时间，秒")
+	flag.IntVar(&configs.Interval, "interval", 180, "--interval 180 #接口防止重刷时间")
 
 	flag.StringVar(&configs.LogLevel, "logLevel", "info", "--logLevel info # 日志等级")
-	flag.StringVar(&configs.LogEncoding, "logEncoding", "console", "--logEncoding console # 日志输出格式 console 或 json")
+	flag.StringVar(&configs.LogFormat, "logFormat", "console", "--logFormat console # 日志输出格式 console 或 json")
 
 	flag.StringVar(&configs.DataPath, "dataPath", "./data", "--dataPath ./data # 数据日志文件保存路径")
 
@@ -86,7 +87,7 @@ func checkFlag() bool {
 // 初始化 zap日志框架
 func initLogger() {
 	level := getLevel()
-	encoding := configs.LogEncoding
+	encoding := configs.LogFormat
 	// 保留两个变量，但设置成同一个文件
 	//stdout := configs.DataPath + "/log/stdout.log"
 	//stderr := configs.DataPath + "/log/stderr.log"
@@ -173,23 +174,23 @@ func cronSummary() {
 	t := carbon.Now()
 	qryImportantData := tools.GetQryImportantData(configs.Username, configs.Password)
 	//userFluxPackage := tools.GetUserFluxPackage(configs.Username, configs.Password)
-	configs.Summary = tools.ToSummary(qryImportantData, configs.Username, t)
+	configs.Summary = tools.ParseSummary(qryImportantData, configs.Username, t)
 }
 
 // 初始化访问接口
 func initIris() {
 	irisApp := iris.New()
 	irisApp.Use(middleware)
-	irisApp.Handle(iris.MethodGet, "/show/flow", flow)
+	irisApp.Handle(iris.MethodGet, "/show/traffic", traffic)
 	irisApp.Handle(iris.MethodGet, "/show/detail", packageDetail)
-	irisApp.Handle(iris.MethodGet, "/show/flowPackage", flowPackage)
+	irisApp.Handle(iris.MethodGet, "/show/trafficPackage", trafficPackage)
 	if configs.Dev {
 		irisApp.Handle(iris.MethodGet, "/refresh", refresh)
 
 		irisApp.Handle(iris.MethodGet, "/show/qryImportantData", qryImportantData)
 		irisApp.Handle(iris.MethodGet, "/show/userFluxPackage", userFluxPackage)
 	}
-	err := irisApp.Run(iris.Addr(":" + configs.Prot))
+	err := irisApp.Run(iris.Addr(":" + configs.Port))
 	if err != nil {
 		configs.Logger.Error("InitIris error", err)
 	}
@@ -200,22 +201,22 @@ func middleware(ctx iris.Context) {
 	ctx.Next()
 }
 
-var flowLastTime carbon.Carbon
+var trafficLastTime carbon.Carbon
 
 // 获取流量信息接口
-func flow(ctx iris.Context) {
+func traffic(ctx iris.Context) {
 
-	if carbon.Now().Lt(flowLastTime.AddSeconds(configs.IntervalsTime)) {
+	if carbon.Now().Lt(trafficLastTime.AddSeconds(configs.Interval)) {
 		ctx.JSON(iris.Map{"code": 200, "data": desensitization(configs.Summary)})
 		return
 	}
 
-	flowLastTime = carbon.Now()
+	trafficLastTime = carbon.Now()
 
 	t := carbon.Now()
 
 	qryImportantData := tools.GetQryImportantData(configs.Username, configs.Password)
-	configs.Summary = tools.ToSummary(qryImportantData, configs.Username, t)
+	configs.Summary = tools.ParseSummary(qryImportantData, configs.Username, t)
 
 	summary := desensitization(configs.Summary)
 	ctx.JSON(iris.Map{"code": 200, "data": summary})
@@ -228,8 +229,8 @@ func packageDetail(ctx iris.Context) {
 	})
 }
 
-func flowPackage(ctx iris.Context) {
-	ctx.JSON(&models.FlowPackage{
+func trafficPackage(ctx iris.Context) {
+	ctx.JSON(&models.TrafficPackage{
 		Result: 410,
 		Msg:    "接口已失效",
 	})
@@ -239,7 +240,7 @@ var qryImportantVisitLastTime carbon.Carbon
 var qryImportantDetailRequest *models.Result[models.ImportantData]
 
 func qryImportantData(ctx iris.Context) {
-	if carbon.Now().Lt(qryImportantVisitLastTime.AddSeconds(configs.IntervalsTime)) {
+	if carbon.Now().Lt(qryImportantVisitLastTime.AddSeconds(configs.Interval)) {
 		ctx.JSON(&qryImportantDetailRequest)
 		return
 	}
@@ -252,7 +253,7 @@ var userFluxPackageVisitLastTime carbon.Carbon
 var userFluxPackageDetailRequest *models.Result[models.UserFluxPackageData]
 
 func userFluxPackage(ctx iris.Context) {
-	if carbon.Now().Lt(userFluxPackageVisitLastTime.AddSeconds(configs.IntervalsTime)) {
+	if carbon.Now().Lt(userFluxPackageVisitLastTime.AddSeconds(configs.Interval)) {
 		ctx.JSON(&userFluxPackageDetailRequest)
 		return
 	}

--- a/configs/param.go
+++ b/configs/param.go
@@ -2,20 +2,21 @@ package configs
 
 import (
 	"China_Telecom_Monitor/models"
+
 	"go.uber.org/zap"
 )
 
-var Prot string
+var Port string
 var Username string
 var Password string
-var LoginIntervalTime int
-var TimeOut int64
-var IntervalsTime int
+var LoginInterval int
+var Timeout int64
+var Interval int
 
 var DataPath string
 
 var LogLevel string
-var LogEncoding string
+var LogFormat string
 
 var Dev bool
 

--- a/models/detail.go
+++ b/models/detail.go
@@ -20,22 +20,22 @@ type DetailRequest struct {
 }
 
 type DetailItemsRequest struct {
-	OfferType      int                        `json:"offerType"`
-	ProductOFFName string                     `json:"productOFFName"`
-	ProductOfferId string                     `json:"productOfferId"`
-	Items          []*DetailItemsItemsRequest `json:"items"`
+	OfferType        int                        `json:"offerType"`
+	ProductOfferName string                     `json:"productOFFName"`
+	ProductOfferID   string                     `json:"productOfferId"`
+	Items            []*DetailItemsItemsRequest `json:"items"`
 }
 
 type DetailItemsItemsRequest struct {
 	NameType            string `json:"nameType"`
 	OwnerType           string `json:"ownerType"`
-	UnitTypeId          string `json:"unitTypeId"`
+	UnitTypeID          string `json:"unitTypeId"`
 	RatableAmount       string `json:"ratableAmount"`
 	UsageAmount         string `json:"usageAmount"`
 	RatableResourceID   string `json:"ratableResourceID"`
 	BeginTime           string `json:"beginTime"`
 	EndTime             string `json:"endTime"`
-	RatableResourcename string `json:"ratableResourcename"`
+	RatableResourceName string `json:"ratableResourcename"`
 	BalanceAmount       string `json:"balanceAmount"`
 	OwnerID             string `json:"ownerID"`
 }
@@ -53,7 +53,7 @@ type BalanceNew struct {
 	ParaFieldResult string `json:"paraFieldResult"`
 }
 
-type FlowPackage struct {
+type TrafficPackage struct {
 	Result             int    `json:"result"`
 	Msg                string `json:"msg"`
 	UserPackageBalance struct {
@@ -74,15 +74,15 @@ type FlowPackage struct {
 				OwnerType           string `json:"ownerType"`
 				RatableAmount       string `json:"ratableAmount"`
 				RatableResourceID   string `json:"ratableResourceID"`
-				RatableResourcename string `json:"ratableResourcename"`
+				RatableResourceName string `json:"ratableResourcename"`
 				UnitTypeID          string `json:"unitTypeId"`
 				UsageAmount         string `json:"usageAmount"`
 			} `json:"items"`
-			OfferType      int         `json:"offerType"`
-			ProductOFFName string      `json:"productOFFName"`
-			ProductOfferID interface{} `json:"productOfferId"`
-			RatableAmount  string      `json:"ratableAmount"`
-			TotalPercent   string      `json:"totalPercent"`
+			OfferType        int         `json:"offerType"`
+			ProductOfferName string      `json:"productOFFName"`
+			ProductOfferID   interface{} `json:"productOfferId"`
+			RatableAmount    string      `json:"ratableAmount"`
+			TotalPercent     string      `json:"totalPercent"`
 		} `json:"items"`
 		ParaFieldResult       string      `json:"paraFieldResult"`
 		ServiceResultCode     int64       `json:"serviceResultCode"`

--- a/models/telecom.go
+++ b/models/telecom.go
@@ -12,7 +12,7 @@ type LoginRequestContent struct {
 type LoginRequestFieldData struct {
 	AccountType                string `json:"accountType"`
 	Authentication             string `json:"authentication"`
-	DeviceUid                  string `json:"deviceUid"`
+	DeviceUID                  string `json:"deviceUid"`
 	IsChinatelecom             string `json:"isChinatelecom"`
 	LoginAuthCipherAsymmertric string `json:"loginAuthCipherAsymmertric"`
 	LoginType                  string `json:"loginType"`
@@ -27,7 +27,7 @@ type QryImportantDataRequestContent struct {
 type QryImportantDataRequestFieldData struct {
 	ProvinceCode   string `json:"provinceCode"`
 	CityCode       string `json:"cityCode"`
-	ShopId         string `json:"shopId"`
+	ShopID         string `json:"shopId"`
 	IsChinatelecom string `json:"isChinatelecom"`
 	Account        string `json:"account"`
 }
@@ -45,7 +45,7 @@ type UserFluxPackageRequestFieldData struct {
 type RequestHeaderInfos struct {
 	ClientType     string `json:"clientType,omitempty"`
 	Code           string `json:"code,omitempty"`
-	ShopId         string `json:"shopId,omitempty"`
+	ShopID         string `json:"shopId,omitempty"`
 	Source         string `json:"source,omitempty"`
 	SourcePassword string `json:"sourcePassword,omitempty"`
 	Timestamp      string `json:"timestamp,omitempty"`
@@ -76,7 +76,7 @@ type LoginData struct {
 type ImportantData struct {
 	// https://appfuwu.189.cn:9021/query/qryImportantData
 	BalanceInfo    BalanceInfo      `json:"balanceInfo,omitempty"`
-	FlowInfo       FlowInfo         `json:"flowInfo,omitempty"`
+	TrafficInfo    TrafficInfo      `json:"flowInfo,omitempty"`
 	VoiceInfo      VoiceInfo        `json:"voiceInfo,omitempty"`
 	IntegralInfo   IntegralInfo     `json:"integralInfo,omitempty"`
 	StorageInfo    StorageInfo      `json:"storageInfo,omitempty"`
@@ -170,13 +170,13 @@ type Amount struct {
 	Link      string `json:"link"`
 	LinkType  string `json:"linkType"`
 }
-type FlowRegion struct {
+type TrafficRegion struct {
 	Title      string `json:"title"`
 	SubTitle   string `json:"subTitle"`
 	SubTitleHh string `json:"subTitleHh"`
 	IconURL    string `json:"iconUrl"`
 }
-type FlowList struct {
+type TrafficList struct {
 	Title         string `json:"title"`
 	SubTitle      string `json:"subTitle"`
 	BarPercent    string `json:"barPercent"`
@@ -187,15 +187,15 @@ type FlowList struct {
 	RightTitleHh  string `json:"rightTitleHh"`
 	RightTitleEnd string `json:"rightTitleEnd"`
 }
-type FlowInfo struct {
-	CommonFlow        Amount              `json:"commonFlow"`
+type TrafficInfo struct {
+	CommonTraffic     Amount              `json:"commonFlow"`
 	SpecialAmount     Amount              `json:"specialAmount"`
 	TotalAmount       Amount              `json:"totalAmount"`
-	FlowRegion        FlowRegion          `json:"flowRegion"`
+	TrafficRegion     TrafficRegion       `json:"flowRegion"`
 	LoopTips          []interface{}       `json:"loopTips"`
 	ImportantDataBtns []ImportantDataBtns `json:"importantDataBtns"`
 	AdConfigs         []AdConfigs         `json:"adConfigs"`
-	FlowList          []FlowList          `json:"flowList"`
+	TrafficList       []TrafficList       `json:"flowList"`
 	ErrorMes          string              `json:"errorMes"`
 }
 type VoiceDataInfo struct {
@@ -247,11 +247,11 @@ type StorageDataInfo struct {
 }
 type StorageInfo struct {
 	StorageDataInfo   StorageDataInfo     `json:"storageDataInfo"`
-	FlowRegion        FlowRegion          `json:"flowRegion"`
+	TrafficRegion     TrafficRegion       `json:"flowRegion"`
 	LoopTips          []interface{}       `json:"loopTips"`
 	ImportantDataBtns []ImportantDataBtns `json:"importantDataBtns"`
 	AdConfigs         []AdConfigs         `json:"adConfigs"`
-	FlowList          []FlowList          `json:"flowList"`
+	TrafficList       []TrafficList       `json:"flowList"`
 	ErrorMes          string              `json:"errorMes"`
 }
 type ThresholdMesList struct {

--- a/tools/chinaTelecom.go
+++ b/tools/chinaTelecom.go
@@ -50,7 +50,7 @@ func checkLogin() bool {
 func login(mobile, password string) {
 
 	t := time.Now().Format("20060102150400")
-	deviceUID := fmt.Sprintln("%s4%4", randStr(12), randStr(3))
+	deviceUID := fmt.Sprintf("%s4%4", randStr(12), randStr(3))
 
 	e := fmt.Sprintf("iPhone 14 15.4.%s%s%s%s0$$$0.", randStr(12), mobile, t, password)
 	enc, err := encrypt(e)

--- a/tools/chinaTelecom.go
+++ b/tools/chinaTelecom.go
@@ -10,16 +10,17 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/golang-module/carbon/v2"
 	"io"
 	"math/big"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/golang-module/carbon/v2"
 )
 
-func ChinaTelecomLogin(username, password string) bool {
+func Login(username, password string) bool {
 
 	if !checkLogin() {
 		return false
@@ -37,10 +38,10 @@ func checkLogin() bool {
 	// 上次获取token时间
 	getTokenTime := carbon.CreateFromTimestamp(token.LoginLastTime)
 	// 下次获取token时间 = 上次获取token时间 + 获取token间隔时间
-	nextTimeGetTokenTime := getTokenTime.AddSeconds(configs.LoginIntervalTime)
+	nextTimeGetTokenTime := getTokenTime.AddSeconds(configs.LoginInterval)
 	// 比较 下次获取token时间 是否大于 现在时间
 	if nextTimeGetTokenTime.Gt(carbon.Now()) {
-		configs.Logger.Error(strconv.Itoa(configs.LoginIntervalTime) + " 秒内最多登录一次，下次获取token时间为" + nextTimeGetTokenTime.ToDateTimeString() + "，避免被封号")
+		configs.Logger.Error(strconv.Itoa(configs.LoginInterval) + " 秒内最多登录一次，下次获取token时间为" + nextTimeGetTokenTime.ToDateTimeString() + "，避免被封号")
 		return false
 	}
 	return true
@@ -49,7 +50,7 @@ func checkLogin() bool {
 func login(mobile, password string) {
 
 	t := time.Now().Format("20060102150400")
-	deviceUid := fmt.Sprintln("%s4%4", randStr(12), randStr(3))
+	deviceUID := fmt.Sprintln("%s4%4", randStr(12), randStr(3))
 
 	e := fmt.Sprintf("iPhone 14 15.4.%s%s%s%s0$$$0.", randStr(12), mobile, t, password)
 	enc, err := encrypt(e)
@@ -63,7 +64,7 @@ func login(mobile, password string) {
 			FieldData: models.LoginRequestFieldData{
 				AccountType:                "",
 				Authentication:             encodePhone(password),
-				DeviceUid:                  deviceUid,
+				DeviceUID:                  deviceUID,
 				IsChinatelecom:             "0",
 				LoginAuthCipherAsymmertric: enc,
 				LoginType:                  "4",
@@ -118,7 +119,7 @@ func GetQryImportantData(mobile, password string) *models.Result[models.Importan
 			FieldData: models.QryImportantDataRequestFieldData{
 				ProvinceCode:   "600101",
 				CityCode:       "8441900",
-				ShopId:         "20002",
+				ShopID:         "20002",
 				IsChinatelecom: "0",
 				Account:        transPhone(mobile),
 			},
@@ -171,7 +172,7 @@ func initHeaderInfos(mobile, code, t string) models.RequestHeaderInfos {
 		ClientType:     "#" + configs.ClientVersion + "#channel50#iPhone 14 Pro#",
 		Timestamp:      t,
 		Code:           code,
-		ShopId:         "20002",
+		ShopID:         "20002",
 		Source:         "110003",
 		SourcePassword: "Sid98s",
 		UserLoginName:  encodePhone(mobile),
@@ -248,7 +249,7 @@ func post[C, D any](requestUrl string, requestBody models.Request[C], mobile, pa
 	}
 	// token 过期
 	if resultData.HeaderInfos.Code == "X201" && autoLogin && !firstLogin {
-		ChinaTelecomLogin(mobile, password)
+		Login(mobile, password)
 		return post[C, D](requestUrl, requestBody, mobile, password, false, false)
 	}
 	if resultData.HeaderInfos.Code != "0000" || resultData.ResponseData.ResultCode != "0000" {

--- a/tools/conversion.go
+++ b/tools/conversion.go
@@ -2,28 +2,29 @@ package tools
 
 import (
 	"China_Telecom_Monitor/models"
-	"github.com/golang-module/carbon/v2"
 	"strconv"
 	"strings"
+
+	"github.com/golang-module/carbon/v2"
 )
 
-func ToSummary(qryImportantData *models.Result[models.ImportantData], username string, time carbon.Carbon) models.Summary {
+func ParseSummary(qryImportantData *models.Result[models.ImportantData], username string, time carbon.Carbon) models.Summary {
 	var ds models.Summary
 	if qryImportantData == nil || qryImportantData.HeaderInfos.Code != "0000" || qryImportantData.ResponseData.ResultCode != "0000" {
 		return ds
 	}
 	data := qryImportantData.ResponseData.Data
 
-	useFlow, _ := strconv.ParseInt(data.FlowInfo.TotalAmount.Used, 10, 64)
-	balanceFlow, _ := strconv.ParseInt(data.FlowInfo.TotalAmount.Balance, 10, 64)
-	totalFlow := useFlow + balanceFlow
+	usedData, _ := strconv.ParseInt(data.TrafficInfo.TotalAmount.Used, 10, 64)
+	balanceData, _ := strconv.ParseInt(data.TrafficInfo.TotalAmount.Balance, 10, 64)
+	totalData := usedData + balanceData
 
-	generalUse, _ := strconv.ParseInt(data.FlowInfo.CommonFlow.Used, 10, 64)
-	generalBalance, _ := strconv.ParseInt(data.FlowInfo.CommonFlow.Balance, 10, 64)
+	generalUse, _ := strconv.ParseInt(data.TrafficInfo.CommonTraffic.Used, 10, 64)
+	generalBalance, _ := strconv.ParseInt(data.TrafficInfo.CommonTraffic.Balance, 10, 64)
 	generalTotal := generalUse + generalBalance
 
-	specialUse, _ := strconv.ParseInt(data.FlowInfo.SpecialAmount.Used, 10, 64)
-	specialBalance, _ := strconv.ParseInt(data.FlowInfo.SpecialAmount.Balance, 10, 64)
+	specialUse, _ := strconv.ParseInt(data.TrafficInfo.SpecialAmount.Used, 10, 64)
+	specialBalance, _ := strconv.ParseInt(data.TrafficInfo.SpecialAmount.Balance, 10, 64)
 	specialTotal := specialUse + specialBalance
 
 	voiceUsage, _ := strconv.ParseInt(data.VoiceInfo.VoiceDataInfo.Used, 10, 64)
@@ -33,22 +34,22 @@ func ToSummary(qryImportantData *models.Result[models.ImportantData], username s
 	balance := int64(balanceFloat * 100)
 
 	var items []models.SummaryItems
-	flowLists := data.FlowInfo.FlowList
-	if flowLists != nil && len(flowLists) > 0 {
-		items = make([]models.SummaryItems, len(flowLists))
-		for i, flowList := range flowLists {
-			if !strings.Contains(flowList.Title, "流量") {
+	trafficLists := data.TrafficInfo.TrafficList
+	if trafficLists != nil && len(trafficLists) > 0 {
+		items = make([]models.SummaryItems, len(trafficLists))
+		for i, trafficList := range trafficLists {
+			if !strings.Contains(trafficList.Title, "流量") {
 				continue
 			}
 			var use, balanceF int64
-			if strings.Contains(flowList.LeftTitle, "已用") {
-				use, _ = ToInt64(flowList.LeftTitleHh)
+			if strings.Contains(trafficList.LeftTitle, "已用") {
+				use, _ = ParseTraffic(trafficList.LeftTitleHh)
 			}
-			if strings.Contains(flowList.RightTitle, "剩余") {
-				balanceF, _ = ToInt64(flowList.RightTitleHh)
+			if strings.Contains(trafficList.RightTitle, "剩余") {
+				balanceF, _ = ParseTraffic(trafficList.RightTitleHh)
 			}
 			items[i] = models.SummaryItems{
-				Name:  flowList.Title,
+				Name:  trafficList.Title,
 				Use:   use,
 				Total: use + balanceF,
 			}
@@ -57,8 +58,8 @@ func ToSummary(qryImportantData *models.Result[models.ImportantData], username s
 
 	return models.Summary{
 		Username:     username,
-		Use:          useFlow,
-		Total:        totalFlow,
+		Use:          usedData,
+		Total:        totalData,
 		Balance:      balance,
 		VoiceUsage:   voiceUsage,
 		VoiceAmount:  voiceAmount,

--- a/tools/file.go
+++ b/tools/file.go
@@ -8,7 +8,7 @@ import (
 )
 
 // 判断文件是否存在
-func IsExist(file string) bool {
+func FileExist(file string) bool {
 	_, err := os.Stat(file)
 	if err != nil {
 		return os.IsExist(err)
@@ -22,7 +22,7 @@ func Create(path string) (*os.File, error) {
 	//	return nil,errors.New("文件已经存在")
 	//}
 	dir := filepath.Dir(path)
-	if !IsExist(dir) {
+	if !FileExist(dir) {
 		e := os.MkdirAll(dir, 0755)
 		if e != nil {
 			configs.Logger.Error("创建文件夹失败, Error : ", e)

--- a/tools/traffic.go
+++ b/tools/traffic.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func ToInt64(s string) (int64, error) {
+func ParseTraffic(s string) (int64, error) {
 	if strings.Contains(s, "GB") {
 		sn := strings.ReplaceAll(s, "GB", "")
 		n, err := strconv.ParseFloat(sn, 64)
@@ -31,5 +31,5 @@ func ToInt64(s string) (int64, error) {
 	} else if strings.Contains(s, "B") {
 		return 0, nil
 	}
-	return 0, errors.New("文本格式不符合规范")
+	return 0, errors.New("Invalid text format")
 }


### PR DESCRIPTION
- update struct and field names from FlowPackage to TrafficPackage
- rename FlowInfo to TrafficInfo across models
- change function ToSummary to ParseSummary in conversion tools
- standardize variable names like IntervalsTime to Interval

以上是部分修改的内容，主要是变量命名规范相关的更改。

ref https://github.com/LambdaExpression/ChinaTelecomMonitor/issues/29